### PR TITLE
Permissao para scripts inline Content-Security-Policy

### DIFF
--- a/hom-nginx.conf
+++ b/hom-nginx.conf
@@ -40,7 +40,7 @@ http {
     listen 443 ssl http2;
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self';font-src fonts.gstatic.com;style-src 'self' fonts.googleapis.com;" always;
+    add_header Content-Security-Policy "default-src 'self';script-src 'self' 'unsafe-inline';font-src fonts.gstatic.com;style-src 'self' fonts.googleapis.com;connect-src *;" always;
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
     expires $expires;
@@ -54,6 +54,7 @@ http {
 
     location ~* \.(?:ico|css|js|gif|jpe?g|webp|svg|png)$ {
       root /usr/share/nginx/html;
+      include /etc/nginx/mime.types;
       access_log off;
       gzip_static on;
       gzip_comp_level 5;


### PR DESCRIPTION
Adicionado exceção ao CSP para permitir scripts inline, por exemplo <button onClick={script} />