### PR TITLE
Permissão unsafe-eval e img-src CSP

### DIFF
--- a/hom-nginx.conf
+++ b/hom-nginx.conf
@@ -40,7 +40,7 @@ http {
     listen 443 ssl http2;
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self';script-src 'self' 'unsafe-inline';font-src fonts.gstatic.com;style-src 'self' fonts.googleapis.com;connect-src *;" always;
+    add_header Content-Security-Policy "default-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';font-src 'self' fonts.gstatic.com;style-src 'self' fonts.googleapis.com;img-src *;connect-src *;" always;
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
     expires $expires;


### PR DESCRIPTION
# Permissão unsafe-eval e img-src CSP

## Descrição

Corrige problemas com a biblioteca react-pdf-renderer para mostrar certficados

## Como isso foi testado?

- [ ] Testes unitários
- [ ] Teste exploratório
- [x] Não aplicável

## Essa modificação exige atualização da documentação?

Não

## Tipo de alteração

- [ ] Nova feature
- [x] Correção de bugs
- [ ] Alteração de uma funcionalidade já existente
- [ ] Documentação
